### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can set the swipe direction,such as left,top,right and bottom.
 ### Gradle
 ```
 dependencies {
-   	compile 'com.github.liuguangqiang.swipeback:library:1.0.2@aar'
+   	implementation 'com.github.liuguangqiang.swipeback:library:1.0.2@aar'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.