### PR TITLE
Remove attr windowIsTranslucent and add prefix android: before windowActionBar

### DIFF
--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -1,14 +1,13 @@
 <resources>
 
     <style name="Theme.Swipe.Back" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="windowActionBar">false</item>
+        <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
     </style>
 
     <style name="Theme.No.ActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="windowActionBar">false</item>
+        <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
     </style>
 


### PR DESCRIPTION
Two things
1. windowIsTranslucent = true worked fine in portrait mode, but not for landscape. 
Take a look at: [Reference](https://stackoverflow.com/questions/18257989/orientation-locked-when-background-is-transparent)
It can be possible to add att orientation in `AndroidManifest.xml` but but it will lead to some unexpected behavior. (for example, `onConfigurationChanges`...)

2. `windowActionBar`
`ActionBarActivity` is deprecated in revision 22.1.0 of the Support Library and so `AppCompatActivity`.
Try with `android:windowActionBar` for newer library.