### PR TITLE
Upgrade dependencies in order to work with latest API (32)

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,16 +2,14 @@ apply plugin: 'com.android.library'
 //apply from: 'https://raw.github.com/liuguangqiang/gradle-mvn-push/master/gradle-mvn-push.gradle'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
-
+    compileSdkVersion 32
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
+        targetSdkVersion 32
     }
     buildTypes {
         release {
@@ -22,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.appcompat:appcompat:1.6.0-alpha03'
 }

--- a/library/src/main/java/com/liuguangqiang/swipeback/SwipeBackActivity.java
+++ b/library/src/main/java/com/liuguangqiang/swipeback/SwipeBackActivity.java
@@ -1,6 +1,6 @@
 package com.liuguangqiang.swipeback;
 
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;

--- a/library/src/main/java/com/liuguangqiang/swipeback/SwipeBackLayout.java
+++ b/library/src/main/java/com/liuguangqiang/swipeback/SwipeBackLayout.java
@@ -18,9 +18,9 @@ package com.liuguangqiang.swipeback;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.v4.view.ViewCompat;
-import android.support.v4.view.ViewPager;
-import android.support.v4.widget.ViewDragHelper;
+import androidx.core.view.ViewCompat;
+import androidx.viewpager.widget.ViewPager;
+import androidx.customview.widget.ViewDragHelper;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.MotionEvent;


### PR DESCRIPTION
Upgraded AppCompatActivity dependency and switched from the old Android Support Library the new AndroidX library. These changes allow the library to work with the latest API (32 at the time of this writing). Also set compileSDK and targetSDK to 32 version.